### PR TITLE
#159987721 List and update Users functionality

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -147,6 +147,7 @@ class UsersController {
       }
     )
       .then(users => res.status(200).json({
+        // add success message here.
         profiles: users,
       }))
       .catch(next);
@@ -198,6 +199,15 @@ class UsersController {
     const { errors, isValid } = UserValidation.validateProfileInput(req.body);
 
     isValidNumber(req, res);
+
+    // check if user in current session is same with user being updated
+    // prevent user from updating another users' profile
+    if (Number(userId) !== Number(req.userId)) {
+      const error = new Error('you are not allowed to update another user\'s profile');
+      error.status = 401;
+      return next(error);
+    }
+
     if (!isValid) {
       return res.status(400).json({ errors });
     }

--- a/server/tests/controllers/users_profile.js
+++ b/server/tests/controllers/users_profile.js
@@ -27,7 +27,7 @@ const incorrectNameInput = {
 const token = `Bearer ${TokenHelper.generateToken({ id: 1 })}`;
 
 describe('Users Controllers', () => {
-  describe('getUsersProfiles()', () => {
+  describe('getUsersProfiles', () => {
     it('should return all users profile', (done) => {
       chai.request(app)
         .get('/api/users')
@@ -43,7 +43,7 @@ describe('Users Controllers', () => {
     });
   });
 
-  describe('getUserProfileByUsername()', () => {
+  describe('getUserProfileByUsername', () => {
     it('should return response for a single user', (done) => {
       chai.request(app)
         .get('/api/users/andelan')
@@ -70,11 +70,23 @@ describe('Users Controllers', () => {
     });
   });
 
-  describe('updateUserProfile()', () => {
+  describe('updateUserProfile', () => {
+    it('should prevent user from updating other users profiles', (done) => {
+      const unauthorizedUserToken = `Bearer ${TokenHelper.generateToken({ id: 10 })}`;
+      chai.request(app)
+        .put('/api/users/1')
+        .set('Authorization', unauthorizedUserToken)
+        .send(updateContent)
+        .end((error, res) => {
+          expect(res).to.have.status(401);
+          done();
+        });
+    });
     it('should return error for user that does not exist', (done) => {
+      const unexistingUserToken = `Bearer ${TokenHelper.generateToken({ id: 10 })}`;
       chai.request(app)
         .put('/api/users/10')
-        .set('Authorization', token)
+        .set('Authorization', unexistingUserToken)
         .send(updateContent)
         .end((error, res) => {
           expect(res).to.have.status(404);


### PR DESCRIPTION
#### What does this PR do?
prevent user from updating other users profiles

#### Description of Task to be completed?
Users could previously update other users' profile. To prevent this
we simply check the user in the current session and compare it with the
record being updated.

- Include relevant tests


#### How should this be manually tested?
Run `npm run migrate`
Run `npm run start:dev`
send a `PUT` request to `api/users/<userId>` to update user profile

#### What are the relevant pivotal tracker stories?
[#159987721](https://www.pivotaltracker.com/story/show/159987721)