### PR TITLE
#160314849 Users should be able to categorise their articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "NODE_ENV=test nyc mocha --compilers js:babel-register ./server/tests/ --timeout 5000ms --exit --no-deprecation",
     "start": "npm run build && node dist/index.js",
     "build": "rimraf dist/ && babel ./ -d dist/ --ignore node_modules --copy-files",
-    "start:dev": "nodemon --watch server --exec babel-node ./index.js",
+    "start:dev": "npm run migrate && nodemon --watch server --exec babel-node ./index.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "NODE_ENV=test nyc mocha --compilers js:babel-register ./server/tests/ --timeout 5000ms --exit --no-deprecation",
     "start": "npm run build && node dist/index.js",
     "build": "rimraf dist/ && babel ./ -d dist/ --ignore node_modules --copy-files",
-    "start:dev": "npm run migrate && nodemon --watch server --exec babel-node ./index.js",
+    "start:dev": "nodemon --watch server --exec babel-node ./index.js",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "report-coverage": "cat ./coverage/lcov.info | coveralls",
     "coveralls": "nyc --reporter=lcov --reporter=text-lcov npm test"

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -1,14 +1,8 @@
-import jwt from 'jsonwebtoken';
-import dotenv from 'dotenv';
-import { Category, Article } from '../models';
-
-dotenv.config();
-
-const secret = process.env.SECRET_KEY;
+import { Category } from '../models';
 
 /**
  *
- * @description controller class with methods for email verification and confirmation
+ * @description controller class with methods for categorizing articles
  * @class CategoryController
  */
 class CategoryController {
@@ -20,11 +14,19 @@ class CategoryController {
    * @memberof CategoryController
    */
   static getAllCategories(req, res) {
-    Category.findAll({
-      include: [{
-        as: 'article'
-      }]
-    });
+    Category.all()
+      .then(categories => (
+        res.status(200).json({
+          status: 'success',
+          categories,
+        })
+      ))
+      .catch(error => (
+        res.status(400).json({
+          status: 'error',
+          error
+        })
+      ));
   }
 
   /**
@@ -35,7 +37,39 @@ class CategoryController {
    * @memberof CategoryController
    */
   static createCategory(req, res) {
-
+    const newCategory = req.body.name.trim();
+    if (newCategory === '') {
+      return res.status(400).json({
+        status: 'error',
+        error: 'Name field cannot be empty'
+      });
+    }
+    Category.findOne({
+      where: { name: newCategory }
+    })
+      .then((category) => {
+        if (category) {
+          return res.status(409).json({
+            status: 'error',
+            error: 'Category already exists'
+          });
+        }
+        Category.create({
+          name: newCategory,
+        })
+          .then(category => (
+            res.status(201).json({
+              status: 'success',
+              category
+            })
+          ));
+      })
+      .catch(error => (
+        res.status(400).json({
+          status: 'error',
+          error
+        })
+      ));
   }
 
   /**
@@ -45,8 +79,40 @@ class CategoryController {
    * @returns {object} The body of the response message
    * @memberof CategoryController
    */
-  static removeCategory(req, res) {
-    
+  static updateCategory(req, res) {
+    const { categoryName } = req.params;
+    return Category.findOne({
+      where: { name: categoryName }
+    })
+      .then((category) => {
+        if (!category) {
+          return res.status(404).json({
+            status: 'error',
+            error: 'Category does not exist'
+          });
+        }
+        return category.update({
+          name: req.body.name || category.name
+        })
+          .then(() => (
+            res.status(202).json({
+              status: 'status',
+              category,
+            })
+          ))
+          .catch(error => (
+            res.status(400).json({
+              status: 'error',
+              error
+            })
+          ));
+      })
+      .catch(error => (
+        res.status(400).json({
+          status: 'error',
+          error
+        })
+      ));
   }
 
   /**
@@ -56,8 +122,33 @@ class CategoryController {
    * @returns {object} The body of the response message
    * @memberof CategoryController
    */
-  static editCategory(req, res) {
-    
+  static deleteCategory(req, res) {
+    const { categoryName } = req.params;
+    Category.findOne({
+      where: { name: categoryName }
+    })
+      .then((category) => {
+        if (!category) {
+          return res.status(404).json({
+            status: 'error',
+            message: 'Category does not exist'
+          });
+        }
+        return category.destroy()
+          .then(() => (
+            res.status(204).json({
+              status: 'success',
+              message: 'Category deleted successfully'
+            })
+          ))
+          .catch(error => res.status(400).json({ status: 'error', error }));
+      })
+      .catch(error => (
+        res.status(400).json({
+          status: 'error',
+          error,
+        })
+      ));
   }
 }
 

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -44,32 +44,41 @@ class CategoryController {
         error: 'Name field cannot be empty'
       });
     }
-    Category.findOne({
-      where: { name: newCategory }
-    })
-      .then((category) => {
-        if (category) {
-          return res.status(409).json({
+    return Category.all()
+      .then((allCategories) => {
+        if (allCategories.length === 10) {
+          return res.status(400).json({
             status: 'error',
-            error: 'Category already exists'
+            error: 'You cannot have more that 10 article categories'
           });
         }
-        Category.create({
-          name: newCategory,
+        return Category.findOne({
+          where: { name: newCategory }
         })
-          .then(category => (
-            res.status(201).json({
-              status: 'success',
-              category
+          .then((category) => {
+            if (category) {
+              return res.status(409).json({
+                status: 'error',
+                error: 'Article category already exists'
+              });
+            }
+            return Category.create({
+              name: newCategory,
+            })
+              .then(category => (
+                res.status(201).json({
+                  status: 'success',
+                  category
+                })
+              ));
+          })
+          .catch(error => (
+            res.status(400).json({
+              status: 'error',
+              error
             })
           ));
-      })
-      .catch(error => (
-        res.status(400).json({
-          status: 'error',
-          error
-        })
-      ));
+      });
   }
 
   /**
@@ -81,6 +90,13 @@ class CategoryController {
    */
   static updateCategory(req, res) {
     const { categoryName } = req.params;
+    const updatedCategory = req.body.name;
+    if (updatedCategory.trim() === '') {
+      return res.status(400).json({
+        status: 'error',
+        error: 'Name value cannot be empty'
+      });
+    }
     return Category.findOne({
       where: { name: categoryName }
     })
@@ -88,7 +104,7 @@ class CategoryController {
         if (!category) {
           return res.status(404).json({
             status: 'error',
-            error: 'Category does not exist'
+            error: 'Cannot update a category that does not exist'
           });
         }
         return category.update({
@@ -131,14 +147,14 @@ class CategoryController {
         if (!category) {
           return res.status(404).json({
             status: 'error',
-            message: 'Category does not exist'
+            error: 'You cannot delete a ategory does not exist'
           });
         }
         return category.destroy()
           .then(() => (
             res.status(204).json({
               status: 'success',
-              message: 'Category deleted successfully'
+              error: 'Category deleted successfully'
             })
           ))
           .catch(error => res.status(400).json({ status: 'error', error }));

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -1,6 +1,4 @@
-import {
-  Category, Article, ArticleCategory
-} from '../models';
+import { Category, Article, ArticleCategory } from '../models';
 import TokenHelper from '../utils/TokenHelper';
 
 /**
@@ -85,7 +83,7 @@ class CategoryController {
   }
 
   /**
-   * @description Create a new category
+   * @description Updates an existing category
    * @param  {object} req body of the Admin's request
    * @param  {function} res response from the server
    * @returns {object} The body of the response message
@@ -135,7 +133,7 @@ class CategoryController {
   }
 
   /**
-   * @description Create a new category
+   * @description Delete an existing category
    * @param  {object} req body of the Admin's request
    * @param  {function} res response from the server
    * @returns {object} The body of the response message
@@ -254,7 +252,7 @@ class CategoryController {
   }
 
   /**
-   * @description Adds an article to a  category
+   * @description Get all articles in a category
    * @param  {object} req body of the Author's request
    * @param  {function} res response from the server
    * @param  {function} next response from the server
@@ -287,7 +285,7 @@ class CategoryController {
   }
 
   /**
-   * @description Adds an article to a  category
+   * @description Remove an article from a category
    * @param  {object} req body of the Author's request
    * @param  {function} res response from the server
    * @param  {function} next response from the server

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -38,7 +38,7 @@ class CategoryController {
    */
   static createCategory(req, res) {
     const name = req.body.name.trim();
-    const newCategory = `${name.substr(0, 1)}${name.slice(1).toLowerCase()}`;
+    const newCategory = `${name.substr(0, 1).toUpperCase()}${name.slice(1).toLowerCase()}`;
     if (newCategory === '') {
       return res.status(400).json({
         status: 'error',

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -1,0 +1,64 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+import { Category, Article } from '../models';
+
+dotenv.config();
+
+const secret = process.env.SECRET_KEY;
+
+/**
+ *
+ * @description controller class with methods for email verification and confirmation
+ * @class CategoryController
+ */
+class CategoryController {
+  /**
+   * @description Get all categories
+   * @param  {object} req body of the user's request
+   * @param  {function} res response from the server
+   * @returns {object} The body of the response message
+   * @memberof CategoryController
+   */
+  static getAllCategories(req, res) {
+    Category.findAll({
+      include: [{
+        as: 'article'
+      }]
+    });
+  }
+
+  /**
+   * @description Create a new category
+   * @param  {object} req body of the user's request
+   * @param  {function} res response from the server
+   * @returns {object} The body of the response message
+   * @memberof CategoryController
+   */
+  static createCategory(req, res) {
+
+  }
+
+  /**
+   * @description Create a new category
+   * @param  {object} req body of the user's request
+   * @param  {function} res response from the server
+   * @returns {object} The body of the response message
+   * @memberof CategoryController
+   */
+  static removeCategory(req, res) {
+    
+  }
+
+  /**
+   * @description Create a new category
+   * @param  {object} req body of the user's request
+   * @param  {function} res response from the server
+   * @returns {object} The body of the response message
+   * @memberof CategoryController
+   */
+  static editCategory(req, res) {
+    
+  }
+}
+
+export default CategoryController;

--- a/server/controllers/categoryController.js
+++ b/server/controllers/categoryController.js
@@ -1,5 +1,4 @@
 import { Category, Article, ArticleCategory } from '../models';
-import TokenHelper from '../utils/TokenHelper';
 
 /**
  *

--- a/server/controllers/emailVerificationController.js
+++ b/server/controllers/emailVerificationController.js
@@ -70,8 +70,8 @@ class EmailVerificationController {
         }
         if (!token) {
           return res.status(400).json({
-            status: 'success',
-            message: 'Token is invalid'
+            status: 'error',
+            message: 'No Token provided or token is invalid'
           });
         }
         user.emailVerified = true;

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -212,9 +212,9 @@ class UsersController {
     // check if user in current session is same with user being updated
     // prevent user from updating another users' profile
     if (Number(userId) !== Number(req.userId)) {
-      const error = new Error('you are not allowed to update another user\'s profile');
-      error.status = 401;
-      return next(error);
+      const err = new Error('you are not allowed to update another user\'s profile');
+      err.status = 401;
+      return next(err);
     }
 
     if (!isValid) {

--- a/server/migrations/20180906142019-create-category.js
+++ b/server/migrations/20180906142019-create-category.js
@@ -1,0 +1,24 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('Categories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    name: {
+      type: Sequelize.STRING,
+      allowNull: false,
+      unique: true
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('Categories')
+};

--- a/server/migrations/20180908125307-create-article-category.js
+++ b/server/migrations/20180908125307-create-article-category.js
@@ -1,0 +1,25 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('ArticleCategories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    articleId: {
+      type: Sequelize.INTEGER
+    },
+    categoryId: {
+      type: Sequelize.INTEGER
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('ArticleCategories')
+};

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
         model: models.ArticleCategory,
       },
       foreignKey: 'articleId',
-      as: 'category'
+      as: 'article'
     });
   };
   return Article;

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -33,9 +33,15 @@ module.exports = (sequelize, DataTypes) => {
       as: 'tags',
       foreignKey: 'articleId',
     });
-
     Article.hasMany(Comment, {
       foreignKey: 'articleId'
+    });
+    Article.belongsToMany(models.Category, {
+      through: {
+        model: models.ArticleCategory,
+      },
+      foreignKey: 'articleId',
+      as: 'category'
     });
   };
   return Article;

--- a/server/models/articlecategory.js
+++ b/server/models/articlecategory.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = (sequelize, DataTypes) => {
+  const ArticleCategory = sequelize.define('ArticleCategory', {
+    articleId: DataTypes.INTEGER
+  }, {});
+  ArticleCategory.associate = function(models) {
+    // associations can be defined here
+  };
+  return ArticleCategory;
+};

--- a/server/models/articlecategory.js
+++ b/server/models/articlecategory.js
@@ -1,10 +1,7 @@
-'use strict';
 module.exports = (sequelize, DataTypes) => {
   const ArticleCategory = sequelize.define('ArticleCategory', {
-    articleId: DataTypes.INTEGER
+    articleId: DataTypes.INTEGER,
+    categoryId: DataTypes.INTEGER,
   }, {});
-  ArticleCategory.associate = function(models) {
-    // associations can be defined here
-  };
   return ArticleCategory;
 };

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -1,0 +1,20 @@
+module.exports = (sequelize, DataTypes) => {
+  const Category = sequelize.define('Category', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      required: true,
+      unique: true
+    },
+  });
+  Category.associate = (models) => {
+    Category.belongsToMany(models.Article, {
+      through: {
+        model: models.ArticleCategory,
+      },
+      foreignKey: 'categoryId',
+      as: 'category',
+    });
+  };
+  return Category;
+};

--- a/server/routes/api/categoryRoute.js
+++ b/server/routes/api/categoryRoute.js
@@ -5,9 +5,9 @@ import auth from '../../middleware/auth';
 const { authenticateUser, authorizeAuthor, authorizeAdmin } = auth;
 const categoryRouter = Router();
 
-categoryRouter.get('/', authenticateUser, authorizeAuthor, CategoryController.getAllCategories);
+categoryRouter.get('/', authenticateUser, CategoryController.getAllCategories);
 categoryRouter.post('/', authenticateUser, authorizeAdmin, CategoryController.createCategory);
-categoryRouter.put('/:categoryId', authenticateUser, authorizeAdmin, CategoryController.editCategory);
-categoryRouter.delete('/:categoryId', authenticateUser, authorizeAdmin, CategoryController.removeCategory);
+categoryRouter.put('/:categoryName', authenticateUser, authorizeAdmin, CategoryController.updateCategory);
+categoryRouter.delete('/:categoryName', authenticateUser, authorizeAdmin, CategoryController.deleteCategory);
 
 export default categoryRouter;

--- a/server/routes/api/categoryRoute.js
+++ b/server/routes/api/categoryRoute.js
@@ -16,18 +16,20 @@ categoryRouter.put('/:categoryName', authenticateUser, authorizeAdmin, CategoryC
 
 // Admin can delete a category
 categoryRouter.delete('/:categoryName', authenticateUser, authorizeAdmin, CategoryController.deleteCategory);
-// Authors can add their article(s) to a category
 
-categoryRouter.post('/:categoryName', authenticateUser, authorizeAuthor,
-  CategoryController.addArticleToACategory);
+// Authors can add their article(s) to a category
+categoryRouter.post('/:categoryName', authenticateUser, authorizeAuthor, CategoryController.addArticleToACategory);
 
 // Users can get all articles for a category
-categoryRouter.get('/:categoryName/articles', authenticateUser,
-  CategoryController.getAllArticlesForACategory);
+categoryRouter.get(
+  '/:categoryName/articles', authenticateUser,
+  CategoryController.getAllArticlesForACategory
+);
 
 // Authors can remove their article(s) from a category
-categoryRouter.delete('/:categoryName/articles', authenticateUser, authorizeAuthor,
-  CategoryController.removeArticleFromACategory);
-
+categoryRouter.delete(
+  '/:categoryName/articles', authenticateUser, authorizeAuthor,
+  CategoryController.removeArticleFromACategory
+);
 
 export default categoryRouter;

--- a/server/routes/api/categoryRoute.js
+++ b/server/routes/api/categoryRoute.js
@@ -5,9 +5,29 @@ import auth from '../../middleware/auth';
 const { authenticateUser, authorizeAuthor, authorizeAdmin } = auth;
 const categoryRouter = Router();
 
+// Users can get all articles
 categoryRouter.get('/', authenticateUser, CategoryController.getAllCategories);
+
+// Admin can create a new category
 categoryRouter.post('/', authenticateUser, authorizeAdmin, CategoryController.createCategory);
+
+// Admin can update a category
 categoryRouter.put('/:categoryName', authenticateUser, authorizeAdmin, CategoryController.updateCategory);
+
+// Admin can delete a category
 categoryRouter.delete('/:categoryName', authenticateUser, authorizeAdmin, CategoryController.deleteCategory);
+// Authors can add their article(s) to a category
+
+categoryRouter.post('/:categoryName', authenticateUser, authorizeAuthor,
+  CategoryController.addArticleToACategory);
+
+// Users can get all articles for a category
+categoryRouter.get('/:categoryName/articles', authenticateUser,
+  CategoryController.getAllArticlesForACategory);
+
+// Authors can remove their article(s) from a category
+categoryRouter.delete('/:categoryName/articles', authenticateUser, authorizeAuthor,
+  CategoryController.removeArticleFromACategory);
+
 
 export default categoryRouter;

--- a/server/routes/api/categoryRoute.js
+++ b/server/routes/api/categoryRoute.js
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import CategoryController from '../../controllers/categoryController';
+import auth from '../../middleware/auth';
+
+const { authenticateUser, authorizeAuthor, authorizeAdmin } = auth;
+const categoryRouter = Router();
+
+categoryRouter.get('/', authenticateUser, authorizeAuthor, CategoryController.getAllCategories);
+categoryRouter.post('/', authenticateUser, authorizeAdmin, CategoryController.createCategory);
+categoryRouter.put('/:categoryId', authenticateUser, authorizeAdmin, CategoryController.editCategory);
+categoryRouter.delete('/:categoryId', authenticateUser, authorizeAdmin, CategoryController.removeCategory);
+
+export default categoryRouter;

--- a/server/routes/api/index.js
+++ b/server/routes/api/index.js
@@ -5,6 +5,7 @@ import userRoutes from './users';
 import userFollowRoutes from './userFollows';
 import welcomeRoute from './welcome';
 import socialAuth from './socialauth';
+import categoryRouter from './categoryRoute';
 
 
 const routes = Router();
@@ -26,6 +27,7 @@ routes.use('/users/follow', userFollowRoutes);
 routes.use('/', welcomeRoute);
 routes.use('/', socialAuth);
 routes.use('/articles', articlesRouter);
+routes.use('/article-categories', categoryRouter);
 
 
 export default routes;

--- a/server/seeders/20180904121828-user.js
+++ b/server/seeders/20180904121828-user.js
@@ -5,26 +5,6 @@ module.exports = {
   up: queryInterface => queryInterface.bulkInsert('Users',
     [
       {
-        firstName: 'Some',
-        lastName: 'Author',
-        username: 'awesomeAuthor',
-        email: 'sa@mail.com',
-        role: 'admin',
-        hash: bcrypt.hashSync(process.env.ADMIN_PASSWORD, 10),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        firstName: 'Some',
-        lastName: 'User',
-        username: 'randomUser',
-        email: 'su@mail.com',
-        role: 'user',
-        hash: bcrypt.hashSync(process.env.USER_PASSWORD, 10),
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
         firstName: 'author1',
         lastName: 'Author',
         username: 'randomAuthor1',
@@ -43,7 +23,27 @@ module.exports = {
         hash: bcrypt.hashSync(process.env.AUTHOR_PASSWORD, 10),
         createdAt: new Date(),
         updatedAt: new Date(),
-      }
+      },
+      {
+        firstName: 'Some',
+        lastName: 'User',
+        username: 'randomUser',
+        email: 'su@mail.com',
+        role: 'user',
+        hash: bcrypt.hashSync(process.env.USER_PASSWORD, 10),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        firstName: 'Some',
+        lastName: 'Author',
+        username: 'awesomeAuthor',
+        email: 'sa@mail.com',
+        role: 'admin',
+        hash: bcrypt.hashSync(process.env.ADMIN_PASSWORD, 10),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
     ], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Users', null, {})

--- a/server/seeders/20180907122153-category.js
+++ b/server/seeders/20180907122153-category.js
@@ -1,0 +1,31 @@
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('Categories', [
+    {
+      name: 'Technology',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Business',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Politics',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Health',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Entrepreneurship',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ], {}),
+
+  down: queryInterface => queryInterface.bulkDelete('Categories', null, {})
+};

--- a/server/seeders/20180907122153-category.js
+++ b/server/seeders/20180907122153-category.js
@@ -25,6 +25,86 @@ module.exports = {
       createdAt: new Date(),
       updatedAt: new Date(),
     },
+    {
+      name: 'Comics',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Culture',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Film',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Food',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Music',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Sports',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Economy',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Leadership',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Productivity',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Gaming',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Blockchain',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Artificial Intelligence',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Programming',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Science',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Family',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      name: 'Personal Finance',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
   ], {}),
 
   down: queryInterface => queryInterface.bulkDelete('Categories', null, {})

--- a/server/seeders/20180910162119-articles.js
+++ b/server/seeders/20180910162119-articles.js
@@ -1,0 +1,25 @@
+module.exports = {
+  up: queryInterface => queryInterface.bulkInsert('Articles', [
+    {
+      title: 'wildlife conservation',
+      body: 'The conseration of wildlife is essential to ensure the ecosystem is kept in tact',
+      description: 'wildlife',
+      slug: 'wildlife-conservation',
+      authorId: 1,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      title: 'staying fit',
+      body: 'To stay fit, eat well, exercise daily and visit your doctor monthly',
+      description: 'fitness',
+      slug: 'staying-fit',
+      authorId: 2,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+
+  ], {}),
+
+  down: queryInterface => queryInterface.bulkDelete('Person', null, {})
+};

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -30,6 +30,7 @@ describe.only('Categorize articles', () => {
       .end((req, res) => {
         expect(res).to.have.status(200);
         expect(res.body).to.have.property('status');
+        expect(res.body.status).to.equal.property('success');
         expect(res.body).to.have.property('categories');
         done();
       });

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -1,0 +1,87 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import app from '../../../index';
+
+chai.use(chaiHttp);
+
+const adminPassword = process.env.ADMIN_PASSWORD;
+const authorPassword = process.env.AUTHOR_PASSWORD;
+const userPassword = process.env.USER_PASSWORD;
+
+const admin = {
+  email: 'sa@mail.com',
+  password: adminPassword,
+};
+
+const author = {
+  email: 'author1@mail.com',
+  password: authorPassword,
+};
+
+const user = {
+  email: 'su@mail.com',
+  password: userPassword,
+};
+
+describe.only('Categorize articles', () => {
+  it('Gets all categories', (done) => {
+    chai.request(app)
+      .get('/api/article-categories')
+      .end((req, res) => {
+        expect(res).to.have.status(200);
+        expect(res.body).to.have.property('status');
+        expect(res.body).to.have.property('categories');
+        done();
+      });
+  });
+
+  it('Creates a new category for an Admin', (done) => {
+    chai.request(app)
+      .post('/api/article-categories')
+      .send({ name: 'Arts' })
+      .end((req, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.have.property('status');
+        expect(res.body).to.have.property('category');
+        expect(res.body.category).to.equal({ name: 'Arts' });
+        done();
+      });
+  });
+
+  it('Updates an existing category for an Admin', (done) => {
+    chai.request(app)
+      .put('/api/article-categories/2')
+      .send({ name: 'Arts' })
+      .end((req, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.have.property('status');
+        expect(res.body).to.have.property('category');
+        expect(res.body.category).to.equal({ name: 'Arts' });
+        done();
+      });
+  });
+
+  it('Deletes a category for an Admin', (done) => {
+    chai.request(app)
+      .delete('/api/article-categories/1')
+      .end((req, res) => {
+        expect(res).to.have.status(204);
+        expect(res.body).to.have.property('status');
+        expect(res.body).to.have.property('category');
+        expect(res.body.category).to.equal({ name: 'Arts' });
+        done();
+      });
+  });
+
+  it('Adds a category to an article for an Author', (done) => {
+    chai.request(app)
+      .post('/api/articles')
+      .end((req, res) => {
+        expect(res).to.have.status(204);
+        expect(res.body).to.have.property('status');
+        expect(res.body).to.have.property('category');
+        expect(res.body.category).to.equal({ name: 'Arts' });
+        done();
+      });
+  });
+});

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -32,8 +32,9 @@ let adminToken;
 let userToken;
 let authorToken;
 let author2Token;
+let articleId;
 
-describe('Categorizes articles', () => {
+describe.only('Categorizes articles', () => {
   before((done) => {
     chai.request(app)
       .post('/api/users/login')
@@ -78,7 +79,7 @@ describe('Categorizes articles', () => {
 
 
   // Admin can do CRUD operations for categories
-  describe('Accepts CRUD operations from an Admin', () => {
+  describe.only('Accepts CRUD operations from an Admin', () => {
     it('Gets all categories for an Admin', (done) => {
       chai.request(app)
         .get('/api/article-categories')
@@ -219,13 +220,13 @@ describe('Categorizes articles', () => {
         .end((req, res) => {
           expect(res).to.have.status(404);
           expect(res.body.status).to.equal('error');
-          expect(res.body.error).to.equal('You cannot delete a ategory does not exist');
+          expect(res.body.error).to.equal('You cannot delete a category does not exist');
           done();
         });
     });
   });
 
-  describe('Author can add their article to any category', () => {
+  describe.only('Authors can add their article to any category', () => {
     // An author can post an article ============================
     it('Posts an article for an Author', (done) => {
       chai.request(app)
@@ -235,6 +236,7 @@ describe('Categorizes articles', () => {
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
         .end((req, res) => {
+          articleId = res.body.newArticleAlert.createdArticle.id;
           expect(res).to.have.status(200);
           expect(res.body).to.have.property('newArticleAlert');
           expect(res.body.newArticleAlert.createdArticle.title).to.equal('coding');
@@ -248,7 +250,7 @@ describe('Categorizes articles', () => {
     it('Adds an author\'s article to a category', (done) => {
       chai.request(app)
         .post('/api/article-categories/Technology')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -269,7 +271,7 @@ describe('Categorizes articles', () => {
     it('Adds an author\'s article to a category', (done) => {
       chai.request(app)
         .post('/api/article-categories/Business')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -289,7 +291,7 @@ describe('Categorizes articles', () => {
     it('Adds an author\'s article to a category', (done) => {
       chai.request(app)
         .post('/api/article-categories/Health')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -310,7 +312,7 @@ describe('Categorizes articles', () => {
     it('Returns an error if author tries to add an article to more than 3 categories', (done) => {
       chai.request(app)
         .post('/api/article-categories/Politics')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -324,10 +326,10 @@ describe('Categorizes articles', () => {
     });
 
     // Author cannot add the same article twice to the same category
-    it('Returns an error if author tries to add another author\'s article', (done) => {
+    it('Returns an error if article has already been added', (done) => {
       chai.request(app)
         .post('/api/article-categories/Technology')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -341,10 +343,10 @@ describe('Categorizes articles', () => {
     });
 
     // Author cannot add article to a category that does not exist
-    it('Returns an error if author author\'s article to category that does not exist', (done) => {
+    it('Returns an error if author author\'s adds an article to a category that does not exist', (done) => {
       chai.request(app)
         .post('/api/article-categories/Headphones')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -361,7 +363,7 @@ describe('Categorizes articles', () => {
     it('Returns an error if article does not exist', (done) => {
       chai.request(app)
         .post('/api/article-categories/Technology')
-        .send({ articleTitle: 'eating while working' })
+        .send({ articleId: 80 })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -378,7 +380,7 @@ describe('Categorizes articles', () => {
     it('Returns an error if author tries to add another author\'s article', (done) => {
       chai.request(app)
         .post('/api/article-categories/Technology')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${author2Token}`)
         .set('Content-Type', 'application/json')
@@ -386,7 +388,7 @@ describe('Categorizes articles', () => {
           expect(res).to.have.status(403);
           expect(res).to.have.property('status');
           expect(res.body.status).to.equal('error');
-          expect(res.body.error).to.equal('You cannot modify another author\'s article');
+          expect(res.body.error).to.equal('You do not have sufficient permissions for this action');
           done();
         });
     });
@@ -395,7 +397,7 @@ describe('Categorizes articles', () => {
     it('Removes author\'s article from a category', (done) => {
       chai.request(app)
         .delete('/api/article-categories/Technology/articles')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
@@ -412,7 +414,7 @@ describe('Categorizes articles', () => {
     it('Removes author\'s article from a category', (done) => {
       chai.request(app)
         .delete('/api/article-categories/Technology/articles')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${author2Token}`)
         .set('Content-Type', 'application/json')
@@ -420,7 +422,7 @@ describe('Categorizes articles', () => {
           expect(res).to.have.status(403);
           expect(res).to.have.property('status');
           expect(res.body.status).to.equal('error');
-          expect(res.body.error).to.equal('You cannot remove another author\'s article from this category');
+          expect(res.body.error).to.equal('You do not have sufficient permissions for this action');
           done();
         });
     });
@@ -429,7 +431,7 @@ describe('Categorizes articles', () => {
     it('Returns an error if author tries to remove article from a category twice', (done) => {
       chai.request(app)
         .delete('/api/article-categories/Technology/articles')
-        .send({ articleTitle: 'coding' })
+        .send({ articleId })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -79,7 +79,7 @@ describe('Categorizes articles', () => {
 
 
   // Admin can do CRUD operations for categories
-  describe.only('Accepts CRUD operations from an Admin', () => {
+  describe('Accepts CRUD operations from an Admin', () => {
     it('Gets all categories for an Admin', (done) => {
       chai.request(app)
         .get('/api/article-categories')
@@ -108,6 +108,40 @@ describe('Categorizes articles', () => {
           expect(res.body).to.have.property('status');
           expect(res.body).to.have.property('createdCategory');
           expect(res.body.createdCategory.name).to.equal('Design');
+          done();
+        });
+    });
+
+    // Admin cannot post an empty category =======================
+    it('Returns an error if name is empty', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({ name: '' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Name field cannot be empty');
+          done();
+        });
+    });
+
+    // Catches errors while sending request =======================
+    it('Returns error if req body of new category is undefined', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({})
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(500);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error.message).to.equal('Cannot read property \'trim\' of undefined');
           done();
         });
     });
@@ -226,7 +260,7 @@ describe('Categorizes articles', () => {
     });
   });
 
-  describe.only('Authors can add their article to any category', () => {
+  describe('Authors can add their article to any category', () => {
     // An author can post an article ============================
     it('Posts an article for an Author', (done) => {
       chai.request(app)
@@ -338,6 +372,23 @@ describe('Categorizes articles', () => {
           expect(res).to.have.property('status');
           expect(res.body.status).to.equal('error');
           expect(res.body.error).to.equal('Article has already been added to this Category');
+          done();
+        });
+    });
+
+    // Returns an error if req body for adding an article is undefined
+    it('Returns an error if article to be added is undefined', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Technology')
+        .send()
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('Article does not exist');
           done();
         });
     });

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -18,6 +18,11 @@ const author = {
   password: authorPassword,
 };
 
+const author2 = {
+  email: 'author2@mail.com',
+  password: authorPassword
+};
+
 const user = {
   email: 'su@mail.com',
   password: userPassword,
@@ -26,8 +31,9 @@ const user = {
 let adminToken;
 let userToken;
 let authorToken;
+let author2Token;
 
-describe.only('Categorizes articles', () => {
+describe('Categorizes articles', () => {
   before((done) => {
     chai.request(app)
       .post('/api/users/login')
@@ -59,9 +65,21 @@ describe.only('Categorizes articles', () => {
       });
   });
 
+  before((done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .set('Accept', 'application/json')
+      .send(author2)
+      .end((req, res) => {
+        author2Token = res.body.user.token;
+        done();
+      });
+  });
+
+
   // Admin can do CRUD operations for categories
-  describe('Accepts CRUD operations from an Admin', () => {
-    it.only('Gets all categories for an Admin', (done) => {
+  describe.only('Accepts CRUD operations from an Admin', () => {
+    it('Gets all categories for an Admin', (done) => {
       chai.request(app)
         .get('/api/article-categories')
         .set('Accept', 'application/json')
@@ -77,7 +95,7 @@ describe.only('Categorizes articles', () => {
     });
 
     // Admin can create a new category =======================
-    it.only('Creates a new category for an Admin', (done) => {
+    it('Creates a new category for an Admin', (done) => {
       chai.request(app)
         .post('/api/article-categories')
         .send({ name: 'Design' })
@@ -87,14 +105,14 @@ describe.only('Categorizes articles', () => {
         .end((req, res) => {
           expect(res).to.have.status(201);
           expect(res.body).to.have.property('status');
-          expect(res.body).to.have.property('category');
-          expect(res.body.category.name).to.equal('Design');
+          expect(res.body).to.have.property('createdCategory');
+          expect(res.body.createdCategory.name).to.equal('Design');
           done();
         });
     });
 
-    // An admin cannot create a category twice
-    it.only('Returns an error if category already exists', (done) => {
+    // An admin cannot create a category twice ==========================
+    it('Returns an error if category already exists', (done) => {
       chai.request(app)
         .post('/api/article-categories')
         .send({ name: 'Design' })
@@ -110,8 +128,8 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Category name cannot be empty
-    it.only('Returns an error if category name is empty', (done) => {
+    // Category name cannot be empty =====================================
+    it('Returns an error if category name is empty', (done) => {
       chai.request(app)
         .put('/api/article-categories/Business')
         .send({ name: '' })
@@ -127,10 +145,10 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Admin can update an existing category
-    it.only('Updates an existing category for an Admin', (done) => {
+    // Admin can update an existing category ============================
+    it('Updates an existing category for an Admin', (done) => {
       chai.request(app)
-        .put('/api/article-categories/Technology')
+        .put('/api/article-categories/Entrepreneurship')
         .send({ name: 'InfoTech' })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${adminToken}`)
@@ -144,8 +162,8 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Admin cannot update a category that does not exist
-    it.only('Returns an error if category does not exist', (done) => {
+    // Admin cannot update a category that does not exist ==================
+    it('Returns an error if category does not exist', (done) => {
       chai.request(app)
         .put('/api/article-categories/Champion')
         .send({ name: 'InfoTech' })
@@ -161,8 +179,8 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Admin cannot update a category with an empty string
-    it.only('Returns an error if update is an empty string', (done) => {
+    // Admin cannot update a category with an empty string =================
+    it('Returns an error if update is an empty string', (done) => {
       chai.request(app)
         .put('/api/article-categories/Business')
         .send({ name: '' })
@@ -178,8 +196,8 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Admin can delete a category
-    it.only('Deletes a category for an Admin', (done) => {
+    // Admin can delete a category =================================
+    it('Deletes a category for an Admin', (done) => {
       chai.request(app)
         .delete('/api/article-categories/InfoTech')
         .set('Accept', 'application/json')
@@ -191,8 +209,8 @@ describe.only('Categorizes articles', () => {
         });
     });
 
-    // Admin cannot delete a category that does not exists
-    it.only('Does not delete a category that does not exists', (done) => {
+    // Admin cannot delete a category that does not exists ====================
+    it('Does not delete a category that does not exists', (done) => {
       chai.request(app)
         .delete('/api/article-categories/Socialization')
         .set('Accept', 'application/json')
@@ -205,55 +223,224 @@ describe.only('Categorizes articles', () => {
           done();
         });
     });
+  });
 
-    // An author can add their article to a category
-    it('Adds a category to an article for an Author', (done) => {
+  describe.only('Author can add their article to any category', () => {
+    // An author can post an article ============================
+    it('Posts an article for an Author', (done) => {
       chai.request(app)
         .post('/api/articles')
+        .send({ title: 'coding', body: 'coding is fun', description: 'coding is fun' })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
         .end((req, res) => {
-          expect(res).to.have.status(204);
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.property('newArticleAlert');
+          expect(res.body.newArticleAlert.createdArticle.title).to.equal('coding');
+          expect(res.body.newArticleAlert.createdArticle.body).to.equal('coding is fun');
+          expect(res.body.newArticleAlert.createdArticle.description).to.equal('coding is fun');
+          done();
+        });
+    });
+
+    // An author can add their article to a category ============================
+    it('Adds an author\'s article to a category', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Technology')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(202);
           expect(res.body).to.have.property('status');
-          expect(res.body).to.have.property('category');
-          expect(res.body.category).to.equal({ name: 'Arts' });
-          done();
-        });
-    });
-  });
-
-  /*
-  describe.only('Users and authors cannot do CRUD operations on catergories', () => {
-    it('Returns an error if a user tries to create a category', (done) => {
-      chai.request(app)
-        .post('/api/article-categories')
-        .send({ name: 'Lifestyle' })
-        .set('Accept', 'application/json')
-        .set('Authorization', `Bearer ${userToken}`)
-        .set('Content-Type', 'application/json')
-        .end((req, res) => {
-          expect(res).to.have.status(401);
-          expect(res.body).to.have.property('errors');
-          expect(res.body.errors.message).to.equal('you are not an Admin');
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.have.property('created');
+          expect(res.body.created).to.have.property('articleId');
+          expect(res.body.created).to.have.property('categoryId');
+          expect(res.body.created).to.have.property('updatedAt');
+          expect(res.body.created).to.have.property('createdAt');
           done();
         });
     });
 
-    it('Returns an error if an author tries to create a category', (done) => {
+
+    it('Adds an author\'s article to a category', (done) => {
       chai.request(app)
-        .post('/api/article-categories')
-        .send({ name: 'Engineering' })
+        .post('/api/article-categories/Business')
+        .send({ articleTitle: 'coding' })
         .set('Accept', 'application/json')
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
         .end((req, res) => {
-          expect(res).to.have.status(401);
-          expect(res.body).to.have.property('errors');
-          expect(res.body.errors.message).to.equal('you are not an Admin');
+          expect(res).to.have.status(202);
+          expect(res.body).to.have.property('status');
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.have.property('created');
+          expect(res.body.created).to.have.property('articleId');
+          expect(res.body.created).to.have.property('categoryId');
+          expect(res.body.created).to.have.property('updatedAt');
+          expect(res.body.created).to.have.property('createdAt');
+          done();
+        });
+    });
+
+    it('Adds an author\'s article to a category', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Health')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(202);
+          expect(res.body).to.have.property('status');
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.have.property('created');
+          expect(res.body.created).to.have.property('articleId');
+          expect(res.body.created).to.have.property('categoryId');
+          expect(res.body.created).to.have.property('updatedAt');
+          expect(res.body.created).to.have.property('createdAt');
+          done();
+        });
+    });
+
+    // Author cannot add their article(s) to more than 3 categories
+    it('Returns an error if author tries to add an article to more than 3 categories', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Politics')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          console.log(res.body)
+          expect(res).to.have.status(406);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('You cannot have more than 3 categories for each article');
+          done();
+        });
+    });
+
+    // Author cannot add the same article twice to the same category
+    it('Returns an error if author tries to add another author\'s article', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Technology')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(409);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('Article has already been added to this Category');
+          done();
+        });
+    });
+
+    // Author cannot add article to a category that does not exist
+    it('Returns an error if author author\'s article to category that does not exist', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Headphones')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('Category does not exist');
+          done();
+        });
+    });
+
+    // Author cannot add an article that does not exist
+    it('Returns an error if article does not exist', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Technology')
+        .send({ articleTitle: 'eating while working' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('Article does not exist');
+          done();
+        });
+    });
+
+    // Author cannot add another author's article to any category
+    it('Returns an error if author tries to add another author\'s article', (done) => {
+      chai.request(app)
+        .post('/api/article-categories/Technology')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${author2Token}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(403);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('You cannot modify another author\'s article');
+          done();
+        });
+    });
+
+    // Author can remove his article from any category
+    it('Removes author\'s article from a category', (done) => {
+      chai.request(app)
+        .delete('/api/article-categories/Technology/articles')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(202);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('success');
+          expect(res.body.message).to.equal('Your article has been removed from Technology');
+          done();
+        });
+    });
+
+    // Author cannot remove another author's article from any category
+    it('Removes author\'s article from a category', (done) => {
+      chai.request(app)
+        .delete('/api/article-categories/Technology/articles')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${author2Token}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(403);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('You cannot remove another author\'s article from this category');
+          done();
+        });
+    });
+
+    // Author cannot remove an article from a category twice
+    it('Returns an error if author tries to remove article from a category twice', (done) => {
+      chai.request(app)
+        .delete('/api/article-categories/Technology/articles')
+        .send({ articleTitle: 'coding' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res).to.have.property('status');
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('You cannot remove an article that does not exists in this category');
           done();
         });
     });
   });
-  */
 });

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -23,66 +23,237 @@ const user = {
   password: userPassword,
 };
 
-describe.only('Categorize articles', () => {
-  it('Gets all categories', (done) => {
+let adminToken;
+let userToken;
+let authorToken;
+
+describe.only('Categorizes articles', () => {
+  before((done) => {
     chai.request(app)
-      .get('/api/article-categories')
+      .post('/api/users/login')
+      .set('Accept', 'application/json')
+      .send(admin)
       .end((req, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.have.property('status');
-        expect(res.body.status).to.equal.property('success');
-        expect(res.body).to.have.property('categories');
+        adminToken = res.body.user.token;
+        done();
+      });
+  });
+  before((done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .set('Accept', 'application/json')
+      .send(author)
+      .end((req, res) => {
+        authorToken = res.body.user.token;
+        done();
+      });
+  });
+  before((done) => {
+    chai.request(app)
+      .post('/api/users/login')
+      .set('Accept', 'application/json')
+      .send(user)
+      .end((req, res) => {
+        userToken = res.body.user.token;
         done();
       });
   });
 
-  it('Creates a new category for an Admin', (done) => {
-    chai.request(app)
-      .post('/api/article-categories')
-      .send({ name: 'Arts' })
-      .end((req, res) => {
-        expect(res).to.have.status(201);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('category');
-        expect(res.body.category).to.equal({ name: 'Arts' });
-        done();
-      });
+  // Admin can do CRUD operations for categories
+  describe('Accepts CRUD operations from an Admin', () => {
+    it.only('Gets all categories for an Admin', (done) => {
+      chai.request(app)
+        .get('/api/article-categories')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.have.property('status');
+          expect(res.body.status).to.equal('success');
+          expect(res.body).to.have.property('categories');
+          done();
+        });
+    });
+
+    // Admin can create a new category =======================
+    it.only('Creates a new category for an Admin', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({ name: 'Design' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(201);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('category');
+          expect(res.body.category.name).to.equal('Design');
+          done();
+        });
+    });
+
+    // An admin cannot create a category twice
+    it.only('Returns an error if category already exists', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({ name: 'Design' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(409);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Article category already exists');
+          done();
+        });
+    });
+
+    // Category name cannot be empty
+    it.only('Returns an error if category name is empty', (done) => {
+      chai.request(app)
+        .put('/api/article-categories/Business')
+        .send({ name: '' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Name value cannot be empty');
+          done();
+        });
+    });
+
+    // Admin can update an existing category
+    it.only('Updates an existing category for an Admin', (done) => {
+      chai.request(app)
+        .put('/api/article-categories/Technology')
+        .send({ name: 'InfoTech' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(202);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('category');
+          expect(res.body.category.name).to.equal('InfoTech');
+          done();
+        });
+    });
+
+    // Admin cannot update a category that does not exist
+    it.only('Returns an error if category does not exist', (done) => {
+      chai.request(app)
+        .put('/api/article-categories/Champion')
+        .send({ name: 'InfoTech' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Cannot update a category that does not exist');
+          done();
+        });
+    });
+
+    // Admin cannot update a category with an empty string
+    it.only('Returns an error if update is an empty string', (done) => {
+      chai.request(app)
+        .put('/api/article-categories/Business')
+        .send({ name: '' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(400);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('error');
+          expect(res.body.error).to.equal('Name value cannot be empty');
+          done();
+        });
+    });
+
+    // Admin can delete a category
+    it.only('Deletes a category for an Admin', (done) => {
+      chai.request(app)
+        .delete('/api/article-categories/InfoTech')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(204);
+          done();
+        });
+    });
+
+    // Admin cannot delete a category that does not exists
+    it.only('Does not delete a category that does not exists', (done) => {
+      chai.request(app)
+        .delete('/api/article-categories/Socialization')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${adminToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(404);
+          expect(res.body.status).to.equal('error');
+          expect(res.body.error).to.equal('You cannot delete a ategory does not exist');
+          done();
+        });
+    });
+
+    // An author can add their article to a category
+    it('Adds a category to an article for an Author', (done) => {
+      chai.request(app)
+        .post('/api/articles')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(204);
+          expect(res.body).to.have.property('status');
+          expect(res.body).to.have.property('category');
+          expect(res.body.category).to.equal({ name: 'Arts' });
+          done();
+        });
+    });
   });
 
-  it('Updates an existing category for an Admin', (done) => {
-    chai.request(app)
-      .put('/api/article-categories/2')
-      .send({ name: 'Arts' })
-      .end((req, res) => {
-        expect(res).to.have.status(201);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('category');
-        expect(res.body.category).to.equal({ name: 'Arts' });
-        done();
-      });
-  });
+  /*
+  describe.only('Users and authors cannot do CRUD operations on catergories', () => {
+    it('Returns an error if a user tries to create a category', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({ name: 'Lifestyle' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${userToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('errors');
+          expect(res.body.errors.message).to.equal('you are not an Admin');
+          done();
+        });
+    });
 
-  it('Deletes a category for an Admin', (done) => {
-    chai.request(app)
-      .delete('/api/article-categories/1')
-      .end((req, res) => {
-        expect(res).to.have.status(204);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('category');
-        expect(res.body.category).to.equal({ name: 'Arts' });
-        done();
-      });
+    it('Returns an error if an author tries to create a category', (done) => {
+      chai.request(app)
+        .post('/api/article-categories')
+        .send({ name: 'Engineering' })
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${authorToken}`)
+        .set('Content-Type', 'application/json')
+        .end((req, res) => {
+          expect(res).to.have.status(401);
+          expect(res.body).to.have.property('errors');
+          expect(res.body.errors.message).to.equal('you are not an Admin');
+          done();
+        });
+    });
   });
-
-  it('Adds a category to an article for an Author', (done) => {
-    chai.request(app)
-      .post('/api/articles')
-      .end((req, res) => {
-        expect(res).to.have.status(204);
-        expect(res.body).to.have.property('status');
-        expect(res.body).to.have.property('category');
-        expect(res.body.category).to.equal({ name: 'Arts' });
-        done();
-      });
-  });
+  */
 });

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -34,7 +34,7 @@ let authorToken;
 let author2Token;
 let articleId;
 
-describe.only('Categorizes articles', () => {
+describe('Categorizes articles', () => {
   before((done) => {
     chai.request(app)
       .post('/api/users/login')

--- a/server/tests/controllers/category.test.js
+++ b/server/tests/controllers/category.test.js
@@ -78,7 +78,7 @@ describe('Categorizes articles', () => {
 
 
   // Admin can do CRUD operations for categories
-  describe.only('Accepts CRUD operations from an Admin', () => {
+  describe('Accepts CRUD operations from an Admin', () => {
     it('Gets all categories for an Admin', (done) => {
       chai.request(app)
         .get('/api/article-categories')
@@ -225,7 +225,7 @@ describe('Categorizes articles', () => {
     });
   });
 
-  describe.only('Author can add their article to any category', () => {
+  describe('Author can add their article to any category', () => {
     // An author can post an article ============================
     it('Posts an article for an Author', (done) => {
       chai.request(app)
@@ -315,7 +315,6 @@ describe('Categorizes articles', () => {
         .set('Authorization', `Bearer ${authorToken}`)
         .set('Content-Type', 'application/json')
         .end((req, res) => {
-          console.log(res.body)
           expect(res).to.have.status(406);
           expect(res).to.have.property('status');
           expect(res.body.status).to.equal('error');

--- a/server/tests/controllers/index.js
+++ b/server/tests/controllers/index.js
@@ -4,3 +4,4 @@ import './articles';
 import './userFollows';
 import './emailVerification.test';
 import './comments';
+import './category.test';

--- a/server/tests/models/category.model.test.js
+++ b/server/tests/models/category.model.test.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import {
+  sequelize,
+  dataTypes,
+  checkModelName,
+  checkPropertyExists
+} from 'sequelize-test-helpers';
+
+import CategoryModel from '../../models/category';
+
+describe('Category Model', () => {
+  const Category = CategoryModel(sequelize, dataTypes);
+  const category = new Category();
+
+  checkModelName(Category)('Category');
+
+  context('Category model properties', () => {
+    ['name'].forEach(checkPropertyExists(category));
+  });
+
+  context('associations', () => {
+    const Article = 'some dummy artcle';
+
+    before(() => {
+      Category.associate({ Article });
+    });
+
+    it('defined a belongsTo association with Article', () => {
+      expect(Category.belongsTo).to.have.been.calledWith(Article);
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Users can categorize their articles

### Description of tasks to be completed
- Admins can do CRUD operations on categories
- Users can get all categories
- Users can view all the articles in a category
- Authors can add their articles to a category
- Authors can remove their articles from any category

### How to manually test it
- After cloning the repo
- Install and configure Postgresql
- use .envsample to create your environment variables
- run `npm install` to install dependencies
- run `npm run migrate` to create the create tables in the db
- run `npm start:dev` to start the development server
- Admin can create `POST` a new `category/api/article-categories`
- Admin can update `PUT` an existing category `/api/article-categories/:categoryName`
- Admin can delete `DELETE` an existing category `/api/article-categories/:categoryName`
- A user or an author can view all categories `GET` `/api/article-categories`
- A user or an author can view all articles in a category GET /api/article-categories
- Authors can add their article(s) to a category using the articleId `POST` `/api/article-categories/:categoryName`

### What are the relevant pivotal tracker stories?
[160314849](https://www.pivotaltracker.com/story/show/160314849)