### PR TITLE
#159987737 Comments should be able to track edit history

### DIFF
--- a/server/controllers/comments.js
+++ b/server/controllers/comments.js
@@ -1,6 +1,6 @@
 import commentNotification from '../utils/commentNotify';
 import {
-  Article, Comment, User, Reply, CommentLikesDislike
+  Article, Comment, User, Reply, CommentLikesDislike, CommentHistory
 } from '../models';
 
 /**
@@ -493,6 +493,42 @@ class CommentsController {
               comments: commentsResponse,
             });
           })
+          .catch(next);
+      })
+      .catch(next);
+  }
+
+  /**
+   * Get edit history of a comment
+   *
+   * @static
+  * @param {obj} req
+  * @param {obj} res
+  * @param {obj} next
+  * @returns {next/res} returns a response if successful otherwise calls
+  * the next middleware with an error
+   * @memberof CommentsController
+   */
+  static getCommentEdits(req, res, next) {
+    const { commentId } = req.params;
+    Comment
+      .findById(commentId)
+      .then((comment) => {
+        if (!comment) {
+          const error = new Error('comment does not exist');
+          error.status = 404;
+          return next(error);
+        }
+        return CommentHistory
+          .findAll({
+            where: {
+              commentId,
+            }
+          })
+          .then(history => res.status(200).json({
+            status: 'success',
+            history,
+          }))
           .catch(next);
       })
       .catch(next);

--- a/server/controllers/comments.js
+++ b/server/controllers/comments.js
@@ -66,6 +66,48 @@ class CommentsController {
   }
 
   /**
+   * update existing comment
+   *
+   * @static
+   * @param {obj} req
+   * @param {obj} res
+   * @param {obj} next
+   * @returns {next/res} returns a response if successful otherwise calls
+   * the next middleware with an error
+   * @memberof CommentsController
+   */
+  static updateComment(req, res, next) {
+    const { commentId } = req.params;
+    const { userId } = req;
+    Comment.findById(commentId)
+      .then((comment) => {
+        if (!comment) {
+          const error = new Error('comment does not exist');
+          error.status = 404;
+          return next(error);
+        }
+        // check if user in current session is same user that created the comment
+        // prevent user from updating another users' comment
+        if (userId !== comment.commenterId) {
+          const error = new Error('you are not allowed to update another user\'s comment');
+          error.status = 401;
+          return next(error);
+        }
+
+        // update comment
+        return comment.update({
+          body: req.body.comment,
+        })
+          .then(updatedComment => res.status(200).json({
+            status: 'success',
+            comment: updatedComment,
+          }))
+          .catch(next);
+      })
+      .catch(next);
+  }
+
+  /**
    * create Comment reply
    *
    * @static
@@ -397,7 +439,23 @@ class CommentsController {
               as: 'commenter',
               attributes: {
                 exclude: ['hash', 'emailVerified', 'email', 'role', 'createdAt', 'updatedAt']
-              }
+              },
+            },
+            {
+              model: CommentLikesDislike,
+              as: 'likes',
+              where: {
+                reaction: '1',
+              },
+              required: false,
+            },
+            {
+              model: CommentLikesDislike,
+              as: 'dislikes',
+              where: {
+                reaction: '0',
+              },
+              required: false,
             },
             {
               model: Reply,
@@ -411,12 +469,30 @@ class CommentsController {
                 }
               ]
             }
-          ]
+          ],
         })
-          .then(comments => res.status(200).json({
-            status: 'success',
-            comments,
-          }))
+          .then((comments) => {
+            const commentsResponse = comments.map((comment) => {
+              const {
+                id, body, isEdited, createdAt, updatedAt, commenter, Replies, likes, dislikes
+              } = comment;
+              return {
+                id,
+                body,
+                isEdited,
+                createdAt,
+                updatedAt,
+                commenter,
+                replies: Replies,
+                likesCount: likes.length,
+                dislikesCount: dislikes.length,
+              };
+            });
+            res.status(200).json({
+              status: 'success',
+              comments: commentsResponse,
+            });
+          })
           .catch(next);
       })
       .catch(next);

--- a/server/migrations/20180912083647-create-comment-history.js
+++ b/server/migrations/20180912083647-create-comment-history.js
@@ -1,0 +1,34 @@
+
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.createTable('CommentHistories', {
+    id: {
+      allowNull: false,
+      autoIncrement: true,
+      primaryKey: true,
+      type: Sequelize.INTEGER
+    },
+    commentBody: {
+      type: Sequelize.TEXT,
+      allowNull: false,
+    },
+    commentId: {
+      type: Sequelize.INTEGER,
+      onDelete: 'CASCADE',
+      foreignKey: true,
+      allowNull: false,
+      references: {
+        model: 'Comments',
+        key: 'id',
+      }
+    },
+    createdAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      allowNull: false,
+      type: Sequelize.DATE
+    }
+  }),
+  down: queryInterface => queryInterface.dropTable('CommentHistories')
+};

--- a/server/migrations/20180912084520-comment-add-isEdited-column.js
+++ b/server/migrations/20180912084520-comment-add-isEdited-column.js
@@ -1,0 +1,14 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Comments',
+    'isEdited', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: false,
+    },
+  ),
+
+  down: queryInterface => queryInterface.removeColumn(
+    'Comments',
+    'isEdited',
+  )
+};

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -3,6 +3,15 @@ module.exports = (sequelize, DataTypes) => {
     body: {
       type: DataTypes.TEXT,
       allowNull: false,
+      validate: {
+        notEmpty: {
+          msg: 'comment cannot be empty'
+        },
+        len: {
+          args: [2],
+          msg: 'comment cannot be less than two characters long'
+        }
+      },
     },
   }, {});
   Comment.associate = (models) => {

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -17,7 +17,22 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.BOOLEAN,
       defaultValue: false,
     }
-  }, {});
+  }, {
+    hooks: {
+      afterSave: (commentData) => {
+        const { dataValues } = commentData;
+        const { id, body } = dataValues;
+        sequelize.models.CommentHistory.create({
+          commentBody: body,
+          commentId: id,
+        });
+      },
+
+      beforeUpdate: (commentData) => {
+        commentData.isEdited = true;
+      }
+    }
+  });
   Comment.associate = (models) => {
     const {
       User, Article, Reply, CommentLikesDislike, CommentHistory

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -13,10 +13,14 @@ module.exports = (sequelize, DataTypes) => {
         }
       },
     },
+    isEdited: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    }
   }, {});
   Comment.associate = (models) => {
     const {
-      User, Article, Reply, CommentLikesDislike
+      User, Article, Reply, CommentLikesDislike, CommentHistory
     } = models;
     Comment.belongsTo(User, {
       as: 'commenter',
@@ -38,9 +42,14 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'commentId',
       as: 'likes',
     });
+
     Comment.hasMany(CommentLikesDislike, {
       foreignKey: 'commentId',
       as: 'dislikes',
+    });
+
+    Comment.hasMany(CommentHistory, {
+      foreignKey: 'commentId',
     });
   };
   return Comment;

--- a/server/models/commentHistory.js
+++ b/server/models/commentHistory.js
@@ -6,7 +6,9 @@ module.exports = (sequelize, DataTypes) => {
     },
   }, {});
   CommentHistory.associate = (models) => {
-    CommentHistory.belongsTo(models.Comment);
+    CommentHistory.belongsTo(models.Comment, {
+      foreignKey: 'commentId'
+    });
   };
   return CommentHistory;
 };

--- a/server/models/commentHistory.js
+++ b/server/models/commentHistory.js
@@ -1,0 +1,12 @@
+module.exports = (sequelize, DataTypes) => {
+  const CommentHistory = sequelize.define('CommentHistory', {
+    commentBody: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+    },
+  }, {});
+  CommentHistory.associate = (models) => {
+    CommentHistory.belongsTo(models.Comment);
+  };
+  return CommentHistory;
+};

--- a/server/models/reply.js
+++ b/server/models/reply.js
@@ -4,6 +4,15 @@ module.exports = (sequelize, DataTypes) => {
     reply: {
       type: DataTypes.TEXT,
       allowNull: false,
+      validate: {
+        notEmpty: {
+          msg: 'comment cannot be empty'
+        },
+        len: {
+          args: [2],
+          msg: 'comment cannot be less than two characters long'
+        }
+      },
     }
   }, {});
   Reply.associate = (models) => {

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -12,6 +12,7 @@ router.post('/', authenticateUser, authorizeAuthor, ArticleController.create);
 router.post('/:article_slug/comments', authenticateUser, CommentsController.createComment);
 router.post('/:article_slug/comments/:commentId', authenticateUser, CommentsController.createCommentReply);
 router.get('/:article_slug/comments/:commentId', authenticateUser, CommentsController.getCommentById);
+router.get('/:article_slug/comments/:commentId/edits', authenticateUser, CommentsController.getCommentEdits);
 router.post('/:article_slug/comments/:commentId/:reaction', authenticateUser, CommentsController.likeOrDislikeComment);
 router.get('/:article_slug/comments/:commentId/reaction_status', authenticateUser, CommentsController.checkReactionStatus);
 router.get('/:article_slug/comments', authenticateUser, CommentsController.getArticleComments);

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -14,6 +14,7 @@ router.post('/:article_slug/comments/:commentId', authenticateUser, CommentsCont
 router.get('/:article_slug/comments/:commentId', authenticateUser, CommentsController.getCommentById);
 router.post('/:article_slug/comments/:commentId/:reaction', authenticateUser, CommentsController.likeOrDislikeComment);
 router.get('/:article_slug/comments/:commentId/reaction_status', authenticateUser, CommentsController.checkReactionStatus);
+router.get('/:article_slug/comments', authenticateUser, CommentsController.getArticleComments);
 router.get('/', authenticateUser, ArticleController.getAll);
 router.get('/:articleId/reactions', authenticateUser, LikeDislike.getLikesDislikes);
 router.get('/:articleId/reactions/status', authenticateUser, LikeDislike.getReactionStatus);

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -15,6 +15,7 @@ router.get('/:article_slug/comments/:commentId', authenticateUser, CommentsContr
 router.post('/:article_slug/comments/:commentId/:reaction', authenticateUser, CommentsController.likeOrDislikeComment);
 router.get('/:article_slug/comments/:commentId/reaction_status', authenticateUser, CommentsController.checkReactionStatus);
 router.get('/:article_slug/comments', authenticateUser, CommentsController.getArticleComments);
+router.put('/:article_slug/comments/:commentId', authenticateUser, CommentsController.updateComment);
 router.get('/', authenticateUser, ArticleController.getAll);
 router.get('/:articleId/reactions', authenticateUser, LikeDislike.getLikesDislikes);
 router.get('/:articleId/reactions/status', authenticateUser, LikeDislike.getReactionStatus);

--- a/server/tests/controllers/comments.js
+++ b/server/tests/controllers/comments.js
@@ -18,6 +18,10 @@ const reply = {
   reply: 'some reply to some insightful comment'
 };
 
+const commentUpdatePayload = {
+  comment: 'updated the content of insightful comment'
+};
+
 describe('Comment Controller', () => {
   // drop(if exists) and create user table
   before((done) => {
@@ -183,6 +187,74 @@ describe('Comment Controller', () => {
         .end((err, res) => {
           expect(err).to.not.exist;
           expect(res.status).to.equal(404);
+          done();
+        });
+    });
+  });
+
+  describe('updateComment', () => {
+    it('should update an existing comment', (done) => {
+      request(app)
+        .put('/api/articles/test-article-slug12345/comments/1')
+        .set('Authorization', token)
+        .send(commentUpdatePayload)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.type).to.equal('application/json');
+          expect(res.status).to.equal(200);
+          expect(res.body.status).to.equal('success');
+          done();
+        });
+    });
+
+    it('should return a 404 error for a non-existing comment', (done) => {
+      request(app)
+        .put('/api/articles/test-article-slug12345/comments/4000')
+        .set('Authorization', token)
+        .send(commentUpdatePayload)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(404);
+          done();
+        });
+    });
+
+    it('should not allow a user update another users\' comment', (done) => {
+      const unauthorizedUserToken = `Bearer ${TokenHelper.generateToken({ id: 10 })}`;
+      request(app)
+        .put('/api/articles/test-article-slug12345/comments/1')
+        .set('Authorization', unauthorizedUserToken)
+        .send(commentUpdatePayload)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(401);
+          done();
+        });
+    });
+
+    it('should return the updated comment', (done) => {
+      request(app)
+        .put('/api/articles/test-article-slug12345/comments/1')
+        .set('Authorization', token)
+        .send(commentUpdatePayload)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.type).to.equal('application/json');
+          expect(res.body.comment).to.be.an('object');
+          done();
+        });
+    });
+
+    it('should set the \'isEdited\' field to true', (done) => {
+      request(app)
+        .put('/api/articles/test-article-slug12345/comments/1')
+        .set('Authorization', token)
+        .send(commentUpdatePayload)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.type).to.equal('application/json');
+          expect(res.body.comment).to.be.an('object');
+          expect(res.body.comment.isEdited).to.equal(true);
           done();
         });
     });

--- a/server/tests/controllers/comments.js
+++ b/server/tests/controllers/comments.js
@@ -259,4 +259,31 @@ describe('Comment Controller', () => {
         });
     });
   });
+
+  describe('getCommentEdits', () => {
+    it('should fetch all edits for a comment', (done) => {
+      request(app)
+        .get('/api/articles/test-article-slug12345/comments/1/edits')
+        .set('Authorization', token)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(200);
+          expect(res.body.status).to.equal('success');
+          expect(res.body.history).to.be.an('array');
+          done();
+        });
+    });
+
+    it('should return a 404 if comment does not exist', (done) => {
+      request(app)
+        .post('/api/articles/test-article-slug-slug12345/comments/3939')
+        .set('Authorization', token)
+        .send(reply)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(404);
+          done();
+        });
+    });
+  });
 });

--- a/server/tests/controllers/comments.js
+++ b/server/tests/controllers/comments.js
@@ -161,4 +161,30 @@ describe('Comment Controller', () => {
         });
     });
   });
+
+  describe('getArticleComments', () => {
+    it('should fetch all comments and replies for an article', (done) => {
+      request(app)
+        .get('/api/articles/test-article-slug12345/comments')
+        .set('Authorization', token)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(200);
+          expect(res.body.status).to.equal('success');
+          done();
+        });
+    });
+
+    it('should return a 404 if article does not exist', (done) => {
+      request(app)
+        .post('/api/articles/test-article-slug-does-not-exist/comments')
+        .set('Authorization', token)
+        .send(reply)
+        .end((err, res) => {
+          expect(err).to.not.exist;
+          expect(res.status).to.equal(404);
+          done();
+        });
+    });
+  });
 });

--- a/server/tests/models/commentHistory.model.test.js
+++ b/server/tests/models/commentHistory.model.test.js
@@ -1,0 +1,31 @@
+const {
+  sequelize,
+  dataTypes,
+  checkModelName,
+  checkPropertyExists
+} = require('sequelize-test-helpers');
+const { expect } = require('chai');
+
+const CommentHistoryModel = require('../../models/commentHistory');
+
+describe('comment history model', () => {
+  const CommentHistory = CommentHistoryModel(sequelize, dataTypes);
+  const commentHistory = new CommentHistory();
+
+  checkModelName(CommentHistory)('CommentHistory');
+  // test commentHistory model properties
+  context('comment history model properties', () => {
+    [
+      'commentBody'
+    ].forEach(checkPropertyExists(commentHistory));
+  });
+
+  context('associations', () => {
+    const Comment = 'some comment';
+
+    it('defined a belongsTo association with Comment', () => {
+      CommentHistory.associate({ Comment });
+      expect(CommentHistory.belongsTo.calledWith(Comment)).to.equal(true);
+    });
+  });
+});

--- a/server/tests/models/index.js
+++ b/server/tests/models/index.js
@@ -5,3 +5,4 @@ import './comment.model.test';
 import './reply.model.test';
 import './commentLike.model.test';
 import './likeDislike';
+import './commentHistory.model.test';


### PR DESCRIPTION
#### What does this PR do?
implement the ability to track comment edit history.

#### Description of Task to be completed?
Allow users update, their comments, and also track the edit history of each update.
- add update comment method
- prevent users from updating other users' comments
- add relevant tests
- use hooks to update comment history model
- return updated comment with each update
- add method to fetch comment edits

#### How should this be manually tested?
Run `npm run migrate`
Run `npm run start:dev`
send a `POST` request to `/api/articles/` to create an article
send a `POST` request to `/api/articles/:slug/comments` to create a comment
send a `PUT` request to `/api/articles/:slug/comments/:commentId` to update the comment
send a `GET` request to `/api/articles/:slug/comments/:commentId/edits` to retrieve comment edits

#### What are the relevant pivotal tracker stories?
[#159987737](https://www.pivotaltracker.com/story/show/159987737)