### PR TITLE
#160555439 Admin can Get all users and authors Feature

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -281,6 +281,66 @@ class UsersController {
   }
 
   /**
+   * @description Static method for admin to get a list of all users
+   * @param  {object} req body of the Admin's request
+   * @param  {object} res  body of the response message
+   * @param  {function} next next function to be called
+   * @returns {object} The body of the resposne message
+   */
+  static adminGetUsers(req, res) {
+    User.findAll(
+      {
+        where: {
+          role: 'user'
+        },
+        attributes: {
+          exclude: ['hash']
+        }
+      }
+    )
+      .then(users => res.status(200).json({
+        // add success message here.
+        message: 'All registered users returned',
+        status: 'success',
+        profiles: users,
+      }))
+      .catch(error => res.status(500).json({
+        status: 'error',
+        error: { message: error.message ? error.message : 'An error occured during this operation' }
+      }));
+  }
+
+  /**
+   * @description Static method for admin to get a list of all authors
+   * @param  {object} req body of the Admin's request
+   * @param  {object} res  body of the response message
+   * @param  {function} next next function to be called
+   * @returns {object} The body of the resposne message
+   */
+  static adminGetAuthors(req, res) {
+    User.findAll(
+      {
+        where: {
+          role: 'author'
+        },
+        attributes: {
+          exclude: ['hash']
+        }
+      }
+    )
+      .then(authors => res.status(200).json({
+        // add success message here.
+        message: 'All registered authors returned',
+        status: 'success',
+        profiles: authors,
+      }))
+      .catch(error => res.status(500).json({
+        status: 'error',
+        error: { message: error.message ? error.message : 'An error occured during this operation' }
+      }));
+  }
+
+  /**
   * @description Send recovery mail to user's email
   * @param {obj} req response body
   * @param {obj} res request body

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -287,7 +287,7 @@ class UsersController {
    * @param  {function} next next function to be called
    * @returns {object} The body of the resposne message
    */
-  static adminGetUsers(req, res) {
+  static adminGetUsers(req, res, next) {
     User.findAll(
       {
         where: {
@@ -303,11 +303,7 @@ class UsersController {
         message: 'All registered users returned',
         status: 'success',
         profiles: users,
-      }))
-      .catch(error => res.status(500).json({
-        status: 'error',
-        error: { message: error.message ? error.message : 'An error occured during this operation' }
-      }));
+      })).catch(next);
   }
 
   /**
@@ -317,7 +313,7 @@ class UsersController {
    * @param  {function} next next function to be called
    * @returns {object} The body of the resposne message
    */
-  static adminGetAuthors(req, res) {
+  static adminGetAuthors(req, res, next) {
     User.findAll(
       {
         where: {
@@ -333,11 +329,7 @@ class UsersController {
         message: 'All registered authors returned',
         status: 'success',
         profiles: authors,
-      }))
-      .catch(error => res.status(500).json({
-        status: 'error',
-        error: { message: error.message ? error.message : 'An error occured during this operation' }
-      }));
+      })).catch(next);
   }
 
   /**

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -140,29 +140,6 @@ class UsersController {
   }
 
   /**
-   * @description Static method to get all users' profiles
-   * @param  {object} req body of the user's request
-   * @param  {object} res  body of the response message
-   * @param  {function} next next function to be called
-   * @returns {object} The body of the resposne message
-   */
-  static getProfiles(req, res, next) {
-    User.findAll(
-      {
-        attributes: {
-          exclude: ['hash']
-        }
-      }
-    )
-      .then(users => res.status(200).json({
-        // add success message here.
-        status: 'success',
-        profiles: users,
-      }))
-      .catch(next);
-  }
-
-  /**
    * @description Static method to get user's profile by the username
    * @param  {object} req body of the user's request
    * @param  {object} res  body of the response message
@@ -291,38 +268,32 @@ class UsersController {
   static adminGetUsers(req, res, next) {
     const { role } = req.query;
     if (!role) {
-      User.findAll(
-        {
-          where: {
-            role: {
-              [Op.or]: ['user', 'author']
-            }
-          },
-          attributes: {
-            exclude: ['hash']
+      User.findAll({
+        where: {
+          role: {
+            [Op.or]: ['user', 'author', 'admin']
           }
+        },
+        attributes: {
+          exclude: ['hash']
         }
-      )
+      })
         .then(users => res.status(200).json({
-        // add success message here.
           message: 'All registered users returned',
           status: 'success',
           profiles: users,
         })).catch(next);
     } else {
-      User.findAll(
-        {
-          where: {
-            role
-          },
-          attributes: {
-            exclude: ['hash']
-          }
+      User.findAll({
+        where: {
+          role
+        },
+        attributes: {
+          exclude: ['hash']
         }
-      )
+      })
         .then(users => res.status(200).json({
-        // add success message here.
-          message: 'All registered users/authors returned',
+          message: `All registered ${role} returned`,
           status: 'success',
           profiles: users,
         })).catch(next);

--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 import bcrypt from 'bcrypt';
 import sendgrid from '@sendgrid/mail';
 import env from 'dotenv';
@@ -13,7 +15,6 @@ import { isAdmin } from '../utils/verifyRoles';
 
 sendgrid.setApiKey(process.env.SENDGRID_API_KEY);
 env.config();
-
 
 /**
  *
@@ -288,48 +289,44 @@ class UsersController {
    * @returns {object} The body of the resposne message
    */
   static adminGetUsers(req, res, next) {
-    User.findAll(
-      {
-        where: {
-          role: 'user'
-        },
-        attributes: {
-          exclude: ['hash']
+    const { role } = req.query;
+    if (!role) {
+      User.findAll(
+        {
+          where: {
+            role: {
+              [Op.or]: ['user', 'author']
+            }
+          },
+          attributes: {
+            exclude: ['hash']
+          }
         }
-      }
-    )
-      .then(users => res.status(200).json({
+      )
+        .then(users => res.status(200).json({
         // add success message here.
-        message: 'All registered users returned',
-        status: 'success',
-        profiles: users,
-      })).catch(next);
-  }
-
-  /**
-   * @description Static method for admin to get a list of all authors
-   * @param  {object} req body of the Admin's request
-   * @param  {object} res  body of the response message
-   * @param  {function} next next function to be called
-   * @returns {object} The body of the resposne message
-   */
-  static adminGetAuthors(req, res, next) {
-    User.findAll(
-      {
-        where: {
-          role: 'author'
-        },
-        attributes: {
-          exclude: ['hash']
+          message: 'All registered users returned',
+          status: 'success',
+          profiles: users,
+        })).catch(next);
+    } else {
+      User.findAll(
+        {
+          where: {
+            role
+          },
+          attributes: {
+            exclude: ['hash']
+          }
         }
-      }
-    )
-      .then(authors => res.status(200).json({
+      )
+        .then(users => res.status(200).json({
         // add success message here.
-        message: 'All registered authors returned',
-        status: 'success',
-        profiles: authors,
-      })).catch(next);
+          message: 'All registered users/authors returned',
+          status: 'success',
+          profiles: users,
+        })).catch(next);
+    }
   }
 
   /**

--- a/server/docs/swagger.json
+++ b/server/docs/swagger.json
@@ -34,12 +34,12 @@
             "description": "Access user's favorite articles"
         },
         {
-            "name": "Comments",
-            "description": "Access all endpoints associated with article comments"
+          "name": "Comments",
+          "description": "Access all endpoints associated with article comments"
         },
         {
-            "name": "Admin Roles",
-            "description": "Access all endpoints associated with the admin"
+          "name": "Admin Roles",
+          "description": "Access all endpoints associated with the admin"
         },
         {
             "name": "Notifications",
@@ -58,46 +58,20 @@
                 ],
                 "summary": "create a new user",
                 "description": "This endpoints create a new user",
-                "parameters": [
-                    {
-                        "name": "user",
-                        "in": "body",
-                        "description": "Create a new User",
-                        "schema": {
-                            "$ref": "#/definitions/users"
-                        }
+                "parameters": [{
+                    "name": "user",
+                    "in": "body",
+                    "description": "Create a new User",
+                    "schema": {
+                        "$ref": "#/definitions/users"
                     }
-                ],
+                }],
                 "responses": {
                     "201": {
                         "description": "user created successfully"
                     },
                     "400": {
                         "description": "This email has already been registered"
-                    }
-                }
-            },
-            "get": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "get a user profile details",
-                "description": "Returns a list of all user profiles",
-                "parameters": [],
-                "security": [
-                    {
-                        "Bearer": []
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "user details retrieved successfully"
-                    },
-                    "403": {
-                        "description": "no token provided"
-                    },
-                    "401": {
-                        "description": "Invalid authorization format"
                     }
                 }
             }
@@ -149,7 +123,7 @@
                 ],
                 "security": [
                     {
-                        "Bearer": []
+                      "Bearer": []
                     }
                 ],
                 "responses": {
@@ -1347,6 +1321,36 @@
                         "mostReadCategory": {
                             "type": "string"
                         }
+                    }
+                }
+            }
+        },
+        "/api/admin/getUsers?": {
+            "get": {
+                "tags": [
+                    "Admin Roles"
+                ],
+                "summary": "get all users using query terms",
+                "parameters": [
+                    {
+                        "name": "role",
+                        "in": "query",
+                        "required": false,
+                        "type": "string",
+                        "description": "search by role"
+                    }
+                ],
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "500": {
+                        "description": "server error"
                     }
                 }
             }

--- a/server/routes/api/admin.js
+++ b/server/routes/api/admin.js
@@ -23,6 +23,5 @@ adminRoutes.get('/authors/requests/users/:paramsUserId', authenticateUser, autho
 adminRoutes.get('/authors/requests', authenticateUser, authorizeAdmin, authorRequestsController.getAllRequests);
 adminRoutes.delete('/authors/requests/:requestId', authenticateUser, authorizeAdmin, authorRequestsController.deleteUsersRequest);
 adminRoutes.get('/getusers', authenticateUser, authorizeAdmin, UsersController.adminGetUsers);
-adminRoutes.get('/getAuthors', authenticateUser, authorizeAdmin, UsersController.adminGetAuthors);
 
 export default adminRoutes;

--- a/server/routes/api/admin.js
+++ b/server/routes/api/admin.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import auth from '../../middleware/auth';
 import authorRequestsController from '../../controllers/authorRequests';
 import HandleReports from '../../controllers/adminHandleReports';
+import UsersController from '../../controllers/users';
 
 // get authenticateUser method
 const { authenticateUser, authorizeAdmin } = auth;
@@ -21,5 +22,7 @@ adminRoutes.get('/authors/requests/:requestId', authenticateUser, authorizeAdmin
 adminRoutes.get('/authors/requests/users/:paramsUserId', authenticateUser, authorizeAdmin, authorRequestsController.getRequestsByAUser);
 adminRoutes.get('/authors/requests', authenticateUser, authorizeAdmin, authorRequestsController.getAllRequests);
 adminRoutes.delete('/authors/requests/:requestId', authenticateUser, authorizeAdmin, authorRequestsController.deleteUsersRequest);
+adminRoutes.get('/getusers', authenticateUser, authorizeAdmin, UsersController.adminGetUsers);
+adminRoutes.get('/getAuthors', authenticateUser, authorizeAdmin, UsersController.adminGetAuthors);
 
 export default adminRoutes;

--- a/server/routes/api/users.js
+++ b/server/routes/api/users.js
@@ -17,8 +17,6 @@ userRoutes.post('/verify/resend-email', EmailVerificationController.resendVerifi
 
 userRoutes.post('/login', UserController.userLogin);
 
-userRoutes.get('/', authenticateUser, UserController.getProfiles);
-
 userRoutes.get('/:username', authenticateUser, UserController.getProfileByUsername);
 
 userRoutes.put('/:userId', authenticateUser, UserController.updateUserProfile);

--- a/server/tests/controllers/adminGetUser.test.js
+++ b/server/tests/controllers/adminGetUser.test.js
@@ -51,7 +51,7 @@ describe('Admin get Users and Authors function', () => {
       });
   });
 
-  it('should return 200 if all users are returned', (done) => {
+  it('should return 200 if all users and authors are returned', (done) => {
     chai.request(server)
       .get('/api/admin/getUsers')
       .set('Authorization', `Bearer ${token2}`)
@@ -65,11 +65,23 @@ describe('Admin get Users and Authors function', () => {
 
   it('should return 200 if all authors are returned', (done) => {
     chai.request(server)
-      .get('/api/admin/getAuthors')
+      .get('/api/admin/getUsers?role=author')
       .set('Authorization', `Bearer ${token2}`)
       .end((err, res) => {
         res.should.have.status(200);
-        res.body.message.should.equal('All registered authors returned');
+        res.body.message.should.equal('All registered users/authors returned');
+        res.body.status.should.equal('success');
+        done();
+      });
+  });
+
+  it('should return 200 if all users are returned', (done) => {
+    chai.request(server)
+      .get('/api/admin/getUsers?role=user')
+      .set('Authorization', `Bearer ${token2}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.message.should.equal('All registered users/authors returned');
         res.body.status.should.equal('success');
         done();
       });

--- a/server/tests/controllers/adminGetUser.test.js
+++ b/server/tests/controllers/adminGetUser.test.js
@@ -1,0 +1,77 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../../..';
+
+require('dotenv').config();
+
+chai.should();
+
+chai.use(chaiHttp);
+
+const userLogin = {
+  email: 'su@mail.com',
+  password: process.env.USER_PASSWORD
+};
+
+const adminLogin = {
+  email: 'sa@mail.com',
+  password: process.env.ADMIN_PASSWORD
+};
+
+let { token1, token2 } = '';
+
+describe('Admin get Users and Authors function', () => {
+  // get token for accessing the route
+  it('generates a token that cannot access the route', (done) => {
+    chai.request(server).post('/api/users/login').set('Accept', 'application/json').send(userLogin)
+      .end((err, res) => {
+        token1 = res.body.user.token;
+        done();
+      });
+  });
+
+  // get token for accessing the route
+  it('generates a token for accessing the route', (done) => {
+    chai.request(server).post('/api/users/login').set('Accept', 'application/json').send(adminLogin)
+      .end((err, res) => {
+        token2 = res.body.user.token;
+        done();
+      });
+  });
+
+  it('should return 401 if user is not an admin', (done) => {
+    chai.request(server)
+      .get('/api/admin/getUsers')
+      .set('Authorization', `Bearer ${token1}`)
+      .end((err, res) => {
+        res.should.have.status(401);
+        res.body.error.message.should.equal('you are not an Admin');
+        res.body.status.should.equal('error');
+        done();
+      });
+  });
+
+  it('should return 200 if all users are returned', (done) => {
+    chai.request(server)
+      .get('/api/admin/getUsers')
+      .set('Authorization', `Bearer ${token2}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.message.should.equal('All registered users returned');
+        res.body.status.should.equal('success');
+        done();
+      });
+  });
+
+  it('should return 200 if all authors are returned', (done) => {
+    chai.request(server)
+      .get('/api/admin/getAuthors')
+      .set('Authorization', `Bearer ${token2}`)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.body.message.should.equal('All registered authors returned');
+        res.body.status.should.equal('success');
+        done();
+      });
+  });
+});

--- a/server/tests/controllers/adminGetUser.test.js
+++ b/server/tests/controllers/adminGetUser.test.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
+import env from 'dotenv';
 import chaiHttp from 'chai-http';
 import server from '../../..';
 
-require('dotenv').config();
+env.config();
 
 chai.should();
 
@@ -44,21 +45,23 @@ describe('Admin get Users and Authors function', () => {
       .get('/api/admin/getUsers')
       .set('Authorization', `Bearer ${token1}`)
       .end((err, res) => {
+        const { error, status } = res.body;
         res.should.have.status(401);
-        res.body.error.message.should.equal('you are not an Admin');
-        res.body.status.should.equal('error');
+        error.message.should.equal('You are not an Admin');
+        status.should.equal('error');
         done();
       });
   });
 
-  it('should return 200 if all users and authors are returned', (done) => {
+  it('should return 200 if all users are returned', (done) => {
     chai.request(server)
       .get('/api/admin/getUsers')
       .set('Authorization', `Bearer ${token2}`)
       .end((err, res) => {
+        const { message, status } = res.body;
         res.should.have.status(200);
-        res.body.message.should.equal('All registered users returned');
-        res.body.status.should.equal('success');
+        message.should.equal('All registered users returned');
+        status.should.equal('success');
         done();
       });
   });
@@ -68,9 +71,10 @@ describe('Admin get Users and Authors function', () => {
       .get('/api/admin/getUsers?role=author')
       .set('Authorization', `Bearer ${token2}`)
       .end((err, res) => {
+        const { message, status } = res.body;
         res.should.have.status(200);
-        res.body.message.should.equal('All registered users/authors returned');
-        res.body.status.should.equal('success');
+        message.should.equal('All registered author returned');
+        status.should.equal('success');
         done();
       });
   });
@@ -80,9 +84,23 @@ describe('Admin get Users and Authors function', () => {
       .get('/api/admin/getUsers?role=user')
       .set('Authorization', `Bearer ${token2}`)
       .end((err, res) => {
+        const { message, status } = res.body;
         res.should.have.status(200);
-        res.body.message.should.equal('All registered users/authors returned');
-        res.body.status.should.equal('success');
+        message.should.equal('All registered user returned');
+        status.should.equal('success');
+        done();
+      });
+  });
+
+  it('should return 200 if all admins are returned', (done) => {
+    chai.request(server)
+      .get('/api/admin/getUsers?role=admin')
+      .set('Authorization', `Bearer ${token2}`)
+      .end((err, res) => {
+        const { message, status } = res.body;
+        res.should.have.status(200);
+        message.should.equal('All registered admin returned');
+        status.should.equal('success');
         done();
       });
   });

--- a/server/tests/controllers/favorite.test.js
+++ b/server/tests/controllers/favorite.test.js
@@ -9,7 +9,7 @@ chai.should();
 
 chai.use(chaiHttp);
 
-const authorLogin = {
+const userLogin = {
   email: 'su@mail.com',
   password: process.env.USER_PASSWORD
 };
@@ -19,7 +19,7 @@ let { token1 } = '';
 describe('FavoriteArticleController', () => {
   // get token for accessing the route
   it('generates a token for accessing the route', (done) => {
-    chai.request(server).post('/api/users/login').set('Accept', 'application/json').send(authorLogin)
+    chai.request(server).post('/api/users/login').set('Accept', 'application/json').send(userLogin)
       .end((err, res) => {
         token1 = res.body.user.token;
         done();

--- a/server/tests/controllers/index.js
+++ b/server/tests/controllers/index.js
@@ -12,3 +12,4 @@ import './reportArticle.test';
 import './notifications';
 import './readingstats.test';
 import './authorRequests';
+import './adminGetUser.test';

--- a/server/tests/controllers/users_profile.js
+++ b/server/tests/controllers/users_profile.js
@@ -27,22 +27,6 @@ const incorrectNameInput = {
 const token = `Bearer ${TokenHelper.generateToken({ id: 1 })}`;
 
 describe('Users Controllers', () => {
-  describe('getUsersProfiles', () => {
-    it('should return all users profile', (done) => {
-      chai.request(app)
-        .get('/api/users')
-        .set('Authorization', token)
-        .end((error, res) => {
-          const { profiles } = res.body;
-          expect(res).to.have.status(200);
-          profiles[0].should.have.property('firstName');
-          profiles[0].should.have.property('image');
-          profiles[0].should.have.property('email');
-          done();
-        });
-    });
-  });
-
   describe('getUserProfileByUsername', () => {
     it('should return response for a single user', (done) => {
       chai.request(app)


### PR DESCRIPTION
#### What does this PR do?
Implements the ability for the admin to get all users and authors in the app

#### Description of Task to be completed?
Only the Admin can get all the users and authors registered in the app.
An admin can get all users or authors separately using queries or get all the users registered on the platform together.

#### How should this be manually tested?
- clone the repo,
- copy the contents of .env.sample to .env and provide the required values.
- Run ```npm run start:dev```
- log in with an admin account
- send a GET request to ```/api/admin/getusers``` using the admin token in the Authorization header to get all users and authors in the app.
- send a GET request to ```/api/admin/getusers?role=user``` to get all users in the app.
- send a GET request to ```/api/admin/getusers?role=author``` to get all authors in the app.

#### What are the relevant pivotal tracker stories?

#160555439