### PR TITLE
#161248252 Authors should be able to save unpublished articles

### DIFF
--- a/server/controllers/favoriteArticle.js
+++ b/server/controllers/favoriteArticle.js
@@ -1,5 +1,5 @@
 
-import { favoriteArticle } from '../models';
+import { favoriteArticle, Article, User } from '../models';
 import paginateArticle from '../utils/articlesPaginate';
 
 
@@ -92,14 +92,26 @@ class FavoriteArticleController {
     return favoriteArticle.findAndCountAll({
       limit,
       offset,
-      where: { userId: req.userId }
+      where: { userId: req.userId },
+      include: [
+        {
+          model: Article,
+          attributes: ['title', 'description', 'body', 'slug', 'createdAt'],
+          include: [{
+            model: User,
+            as: 'author',
+            attributes: ['firstName', 'lastName', 'username'],
+          }]
+        },
+      ],
+      attributes: { exclude: ['userId', 'articleId', 'createdAt', 'updatedAt'] },
     })
-      .then((favoritedArticle) => {
-        const pagination = paginateArticle(favoritedArticle, currentPage, limit);
+      .then((articles) => {
+        const pagination = paginateArticle(articles, currentPage, limit);
         return res.status(200).json({
           message: 'Your favorite articles',
           pagination,
-          favoritedArticles: favoritedArticle.rows,
+          articles: articles.rows,
           status: 'success'
         });
       })

--- a/server/migrations/20181015191534-article-add-published-column.js
+++ b/server/migrations/20181015191534-article-add-published-column.js
@@ -1,0 +1,14 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Articles',
+    'published', {
+      type: Sequelize.BOOLEAN,
+      defaultValue: true,
+    },
+  ),
+
+  down: queryInterface => queryInterface.removeColumn(
+    'Articles',
+    'published',
+  )
+};

--- a/server/models/article.js
+++ b/server/models/article.js
@@ -26,6 +26,11 @@ module.exports = (sequelize, DataTypes) => {
       allowNull: false,
       defaultValue: true
     },
+    published: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true
+    },
   }, {
     hooks: {
       beforeCreate: (articleData) => {

--- a/server/routes/api/articles.js
+++ b/server/routes/api/articles.js
@@ -11,6 +11,9 @@ const router = Router();
 
 router.get('/search', ArticleController.search);
 router.post('/', authenticateUser, authorizeAuthor, ArticleController.create);
+router.get('/drafts', authenticateUser, authorizeAuthor, ArticleController.getAuthorsDrafts);
+router.get('/published', authenticateUser, authorizeAuthor, ArticleController.getAuthorsArticles);
+router.put('/drafts/:article_slug/publish', authenticateUser, authorizeAuthor, ArticleController.publishDraft);
 router.post('/:article_slug/comments', authenticateUser, CommentsController.createComment);
 router.post('/:article_slug/comments/:commentId', authenticateUser, CommentsController.createCommentReply);
 router.get('/:article_slug/comments/:commentId', authenticateUser, CommentsController.getCommentById);
@@ -19,7 +22,7 @@ router.post('/:article_slug/comments/:commentId/:reaction', authenticateUser, Co
 router.get('/:article_slug/comments/:commentId/reaction_status', authenticateUser, CommentsController.checkReactionStatus);
 router.get('/:article_slug/comments', authenticateUser, CommentsController.getArticleComments);
 router.put('/:article_slug/comments/:commentId', authenticateUser, CommentsController.updateComment);
-router.get('/', authenticateUser, ArticleController.getAllArticles);
+router.get('/', ArticleController.getAllArticles);
 router.get('/:articleId/reactions', authenticateUser, LikeDislike.getLikesDislikes);
 router.get('/:articleId/reactions/status', authenticateUser, LikeDislike.getReactionStatus);
 router.get('/:article_slug', authenticateUser, ArticleController.getArticle, ReadingStatsController.postArticleViewHistory);

--- a/server/tests/controllers/articles.js
+++ b/server/tests/controllers/articles.js
@@ -18,6 +18,13 @@ const author2Login = {
   password: process.env.AUTHOR_PASSWORD
 };
 
+const draft = {
+  title: 'Not ready',
+  body: 'This Article is not yet ready and I do not know why',
+  description: 'Not ready man',
+  published: false
+};
+
 // article for test
 const Article = {
   title: 'jbjkka2 kbviu buibi',
@@ -101,6 +108,26 @@ describe('Articles controller', () => {
           done();
         });
     });
+
+    it('should be able to save article drafts', (done) => {
+      chai.request(server)
+        .post('/api/articles')
+        .set('Accept', 'application/json')
+        .set('Authorization', `Bearer ${token1}`)
+        .set('Content-Type', 'application/json')
+        .send(draft)
+        .end((err, res) => {
+          const { createdArticle } = res.body.newArticleAlert;
+          res.should.have.status(200);
+          res.body.status.should.equal('success');
+          createdArticle.should.have.property('slug');
+          createdArticle.should.have.property('title');
+          createdArticle.should.have.property('description');
+          createdArticle.published.should.equal(false);
+          done();
+        });
+    });
+
 
     it('should create and return the created article object', (done) => {
       chai.request(server)


### PR DESCRIPTION
#### What does this PR do?
- Implement feature where authors can save unpublished articles

#### Description of Task to be completed?
- Update articles table to have a ‘published’ column, set to ’true’ by default
- Authors can save drafts with the endpoint ```POST api/articles/drafts```
- Authors can view drafts with the endpoint ```GET api/articles/drafts```
- Authors can update drafts with the endpoint ```PUT api/articles/<slug>/```
- Authors can publish drafts with the endpoint ```PUT api/articles/drafts/<slug>/publish```
- Authors can view published articles with the endpoint ```GET api/articles/published```

#### How should this be manually tested?
- Clone the repo
- cd into 'thor-ah'
- checkout to the branch ```thor-ah```
- run ```npm install```
- run ```npm run migrate```
- run ```npm run start:dev```
- test the endpoints with postman.

#### What are the relevant pivotal tracker stories?
[161248252](https://www.pivotaltracker.com/story/show/161248252)