### PR TITLE
#161247427 - Fix implementation for users like or dislike on comments

### DIFF
--- a/server/tests/controllers/commentLike.js
+++ b/server/tests/controllers/commentLike.js
@@ -73,17 +73,27 @@ describe('Comment Like Controller', () => {
           done();
         });
     });
-    it('should return error if user dislike an already-liked comment', (done) => {
+    it('should change reaction to dislike type if user selects an opposite reaction', (done) => {
       request(app)
         .post('/api/articles/test-article-slug12345/comments/1/dislike')
         .set('Authorization', token2)
         .send()
         .end((err, res) => {
-          const { message } = res.body.error;
           expect(res.type).to.equal('application/json');
-          expect(res.status).to.equal(400);
-          expect(res.body.status).to.equal('error');
-          expect(message).to.equal('You have already liked this comment');
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.equal('comment disliked');
+          done();
+        });
+    });
+    it('should change reaction to like type if user selects an opposite reaction', (done) => {
+      request(app)
+        .post('/api/articles/test-article-slug12345/comments/1/like')
+        .set('Authorization', token2)
+        .send()
+        .end((err, res) => {
+          expect(res.type).to.equal('application/json');
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.equal('comment liked');
           done();
         });
     });


### PR DESCRIPTION
#### What does this PR do?
bug(comments): fix user experience for comment reactions

#### Description of Task to be completed?
Enable user to automatically update reaction on comment rather than
first undoing initial reaction
- Update user reaction on subsequent requests
- Update relevant tests

#### How should this be manually tested?
Send a `POST` to `/api/articles/:articleSlug/comments/:commentId/:reaction`

`:reaction` should be either `like` or `dislike`.

Subsequent reactions will only update previous ones which is the intended behaviour.

#### Any background context you want to provide?
The previous implementation does not allow for the best User experience.

This fix will enable a user to update a reaction if they send in a new opposing reaction.

#### What are the relevant pivotal tracker stories?
[#161247427](https://www.pivotaltracker.com/story/show/161247427)